### PR TITLE
fix: replace deprecated `version.newcollector`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/nlnwa/veidemann-api/go v1.0.0
 	github.com/prometheus/client_golang v1.19.0
-	github.com/prometheus/common v0.48.0
 	golang.org/x/exp v0.0.0-20231005195138-3e424a577f31
 	golang.org/x/sync v0.7.0
 	google.golang.org/grpc v1.63.2
@@ -19,6 +18,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/metrics/collectors.go
+++ b/metrics/collectors.go
@@ -18,7 +18,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/version"
+	"github.com/prometheus/client_golang/prometheus/collectors/version"
 )
 
 const namespace = "veidemann"


### PR DESCRIPTION
Since
https://github.com/prometheus/common/releases/tag/v0.49.0 `version.newcollector` is deprecated and should be replaced with `collectors/version.NewCollector`